### PR TITLE
Fix bug where GB RBY wouldn't enable plugin

### DIFF
--- a/FlagsEditorEX.cs
+++ b/FlagsEditorEX.cs
@@ -77,7 +77,6 @@
             ctrl.Enabled = savData.Version switch
             {
                 GameVersion.Any or
-                GameVersion.RBY or
                 GameVersion.StadiumJ or
                 GameVersion.Stadium or
                 GameVersion.Stadium2 or

--- a/FlagsOrganizer.cs
+++ b/FlagsOrganizer.cs
@@ -484,7 +484,6 @@
             FlagsOrganizer? flagsOrganizer = savFile.Version switch
             {
                 GameVersion.Any or
-                GameVersion.RBY or
                 GameVersion.StadiumJ or
                 GameVersion.Stadium or
                 GameVersion.Stadium2 or
@@ -503,7 +502,9 @@
                 GameVersion.RD or
                 GameVersion.GN or
                 GameVersion.BU or
-                GameVersion.RB
+                GameVersion.RB or
+                GameVersion.RBY
+
                     => new FlagsGen1RB(),
 
                 GameVersion.YW


### PR DESCRIPTION
When trying to use this plugin with a pokemon Blue save the plugin refused to enable. I don't know if this was intended but after testing this seemed to work fine. Flags were able to be edited and everything was working as expected.